### PR TITLE
Fix log directory permission issues

### DIFF
--- a/meowcoin-core/Dockerfile
+++ b/meowcoin-core/Dockerfile
@@ -83,10 +83,12 @@ RUN chmod +x /entrypoint.sh && \
     mkdir -p /home/meowcoin/.meowcoin && \
     mkdir -p /var/log/meowcoin && \
     chown -R meowcoin:meowcoin /home/meowcoin/.meowcoin && \
-    chown -R meowcoin:meowcoin /var/log/meowcoin
+    chown -R meowcoin:meowcoin /var/log/meowcoin && \
+    chmod 755 /var/log/meowcoin
 
-# Define volume for persistent data
+# Define volumes for persistent data and logs
 VOLUME /home/meowcoin/.meowcoin
+VOLUME /var/log/meowcoin
 
 # Healthcheck removed - using docker-compose healthcheck instead
 

--- a/meowcoin-core/entrypoint.sh
+++ b/meowcoin-core/entrypoint.sh
@@ -38,7 +38,16 @@ ensure_log_dir() {
             LOG_DIR="/tmp"
             LOG_FILE="${LOG_DIR}/meowcoin-core.log"
             echo "Warning: Could not create $LOG_DIR, using /tmp for logs"
+            return
         }
+    fi
+    
+    # Test if we can write to the log directory
+    if ! touch "$LOG_FILE" 2>/dev/null; then
+        # If we can't write to the log directory, fall back to /tmp
+        LOG_DIR="/tmp"
+        LOG_FILE="${LOG_DIR}/meowcoin-core.log"
+        echo "Warning: Cannot write to /var/log/meowcoin, using /tmp for logs"
     fi
 }
 

--- a/meowcoin-monitor/Dockerfile
+++ b/meowcoin-monitor/Dockerfile
@@ -29,10 +29,12 @@ RUN chmod +x /entrypoint.sh
 
 # Create data and log directories
 RUN mkdir -p /data && chown -R monitor:monitor /data && \
-    mkdir -p /var/log/meowcoin && chown -R monitor:monitor /var/log/meowcoin
+    mkdir -p /var/log/meowcoin && chown -R monitor:monitor /var/log/meowcoin && \
+    chmod 755 /var/log/meowcoin
 
-# Set volume
+# Set volumes
 VOLUME /data
+VOLUME /var/log/meowcoin
 
 # Add healthcheck
 HEALTHCHECK --interval=60s --timeout=20s --start-period=120s --retries=5 \

--- a/meowcoin-monitor/entrypoint.sh
+++ b/meowcoin-monitor/entrypoint.sh
@@ -13,7 +13,16 @@ ensure_log_dir() {
             LOG_DIR="/tmp"
             LOG_FILE="${LOG_DIR}/meowcoin-monitor.log"
             echo "Warning: Could not create $LOG_DIR, using /tmp for logs"
+            return
         }
+    fi
+    
+    # Test if we can write to the log directory
+    if ! touch "$LOG_FILE" 2>/dev/null; then
+        # If we can't write to the log directory, fall back to /tmp
+        LOG_DIR="/tmp"
+        LOG_FILE="${LOG_DIR}/meowcoin-monitor.log"
+        echo "Warning: Cannot write to /var/log/meowcoin, using /tmp for logs"
     fi
 }
 


### PR DESCRIPTION
- Add fallback logic to use /tmp if /var/log/meowcoin is not writable
- Test write permissions before attempting to create log files
- Set proper permissions (755) on log directories in Dockerfiles
- Add VOLUME declarations for log directories
- Graceful degradation when volume mounts have permission issues

This fixes the 'Permission denied' errors when writing to log files.