### PR TITLE
Simplify logging to eliminate permission issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ docker compose logs -f meowcoin-core
 
 # Check status
 ./check-status.sh
+
+# Access internal logs
+docker exec meowcoin-node cat /tmp/meowcoin-core.log
 ```
 
 **If deployment fails with "container is unhealthy":**

--- a/check-status.sh
+++ b/check-status.sh
@@ -6,7 +6,7 @@ docker ps -a --filter "name=meowcoin"
 echo ""
 
 # Quick status from monitor
-docker exec meowcoin-monitor cat /var/log/meowcoin/meowcoin-status.txt 2>/dev/null || echo "Status not available"
+docker exec meowcoin-monitor cat /tmp/meowcoin-status.txt 2>/dev/null || echo "Status not available"
 echo ""
 
 # Recent logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,6 @@ services:
       - meowcoin_data:/home/meowcoin/.meowcoin
       # Uncomment the line below to use a custom meowcoin.conf file
       # - ./path/to/your/meowcoin.conf:/home/meowcoin/.meowcoin/meowcoin.conf:ro
-      # Mount logs directory for easier access to logs
-      - meowcoin_logs:/var/log/meowcoin
     healthcheck:
       test: ["CMD-SHELL", "pgrep meowcoind && nc -z localhost 9766"]
       interval: 30s
@@ -90,8 +88,6 @@ services:
       - DEBUG=${DEBUG:-1}
     volumes:
       - meowcoin_data:/data:ro
-      # Mount logs directory for easier access to logs
-      - meowcoin_logs:/var/log/meowcoin
     healthcheck:
       test: ["CMD-SHELL", "nc -z meowcoin-core ${MEOWCOIN_RPC_PORT:-9766} -w 10 || nc -z meowcoin-node ${MEOWCOIN_RPC_PORT:-9766} -w 10 || nc -z localhost ${MEOWCOIN_RPC_PORT:-9766} -w 10 || nc -z 127.0.0.1 ${MEOWCOIN_RPC_PORT:-9766} -w 10"]
       interval: 60s
@@ -130,6 +126,3 @@ volumes:
   meowcoin_data:
     driver: local
     name: meowcoin_data
-  meowcoin_logs:
-    driver: local
-    name: meowcoin_logs

--- a/meowcoin-core/entrypoint.sh
+++ b/meowcoin-core/entrypoint.sh
@@ -26,30 +26,9 @@ generate_random() {
     openssl rand -hex $((length/2))
 }
 
-# Create log directory if it doesn't exist
-LOG_DIR="/var/log/meowcoin"
+# Use /tmp for logs to avoid permission issues
+LOG_DIR="/tmp"
 LOG_FILE="${LOG_DIR}/meowcoin-core.log"
-
-# Function to ensure log directory exists and is writable
-ensure_log_dir() {
-    if [ ! -d "$LOG_DIR" ]; then
-        mkdir -p "$LOG_DIR" 2>/dev/null || {
-            # If we can't create the log directory, fall back to /tmp
-            LOG_DIR="/tmp"
-            LOG_FILE="${LOG_DIR}/meowcoin-core.log"
-            echo "Warning: Could not create $LOG_DIR, using /tmp for logs"
-            return
-        }
-    fi
-    
-    # Test if we can write to the log directory
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-        # If we can't write to the log directory, fall back to /tmp
-        LOG_DIR="/tmp"
-        LOG_FILE="${LOG_DIR}/meowcoin-core.log"
-        echo "Warning: Cannot write to /var/log/meowcoin, using /tmp for logs"
-    fi
-}
 
 # Function to log messages with colors and to file
 log_info() {
@@ -75,9 +54,6 @@ log_error() {
     echo -e "\033[0;31m[ERROR]\033[0m $*" >&2
     echo "$(date '+%Y-%m-%d %H:%M:%S') $msg" >> "$LOG_FILE"
 }
-
-# Ensure log directory exists
-ensure_log_dir
 
 # Start with a clear log file
 echo "=== Meowcoin Core Log Started at $(date) ===" > "$LOG_FILE"

--- a/meowcoin-monitor/entrypoint.sh
+++ b/meowcoin-monitor/entrypoint.sh
@@ -1,30 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Create log directory if it doesn't exist
-LOG_DIR="/var/log/meowcoin"
+# Use /tmp for logs to avoid permission issues
+LOG_DIR="/tmp"
 LOG_FILE="${LOG_DIR}/meowcoin-monitor.log"
-
-# Function to ensure log directory exists and is writable
-ensure_log_dir() {
-    if [ ! -d "$LOG_DIR" ]; then
-        mkdir -p "$LOG_DIR" 2>/dev/null || {
-            # If we can't create the log directory, fall back to /tmp
-            LOG_DIR="/tmp"
-            LOG_FILE="${LOG_DIR}/meowcoin-monitor.log"
-            echo "Warning: Could not create $LOG_DIR, using /tmp for logs"
-            return
-        }
-    fi
-    
-    # Test if we can write to the log directory
-    if ! touch "$LOG_FILE" 2>/dev/null; then
-        # If we can't write to the log directory, fall back to /tmp
-        LOG_DIR="/tmp"
-        LOG_FILE="${LOG_DIR}/meowcoin-monitor.log"
-        echo "Warning: Cannot write to /var/log/meowcoin, using /tmp for logs"
-    fi
-}
 
 # Function to log messages with colors and to file
 log_info() {
@@ -50,9 +29,6 @@ log_error() {
     echo -e "\033[0;31m[ERROR]\033[0m $*" >&2
     echo "$(date '+%Y-%m-%d %H:%M:%S') $msg" >> "$LOG_FILE"
 }
-
-# Ensure log directory exists
-ensure_log_dir
 
 # Start with a clear log file
 echo "=== Meowcoin Monitor Log Started at $(date) ===" > "$LOG_FILE"
@@ -148,7 +124,7 @@ fi
 
 while true; do
     # Create a status file that can be accessed from outside
-    STATUS_FILE="${LOG_DIR}/meowcoin-status.txt"
+    STATUS_FILE="/tmp/meowcoin-status.txt"
     
     # Start with a clean status file
     echo "===================="  > "$STATUS_FILE"


### PR DESCRIPTION
- Remove log volume mounts that were causing permission problems
- Use /tmp for all internal logs (accessible via docker exec)
- Remove complex permission handling and fallback logic
- Update check-status.sh and README for new log locations
- Logs still available via 'docker logs' command
- Eliminates all permission warnings and startup issues

This makes the containers much more reliable and portable.